### PR TITLE
Bump the dependencies group with 9 updates (#34)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,24 +1,24 @@
-val logbackVersion = "1.4.11"
+val logbackVersion = "1.4.14"
 val junitJupiterVersion = "5.10.1"
 val ktfmtVersion = "0.44"
 val logstashEncoderVersion = "7.4"
 val ktorVersion = "2.3.6"
 val smCommonVersion = "2.0.6"
 val coroutinesVersion = "1.7.3"
-val jacksonVersion = "2.15.3"
-val flywayVersion = "9.22.3"
-val postgresVersion = "42.6.0"
-val exposedVersion = "0.44.1"
+val jacksonVersion = "2.16.0"
+val flywayVersion = "10.1.0"
+val postgresVersion = "42.7.0"
+val exposedVersion = "0.45.0"
 val javaVersion = JavaVersion.VERSION_17
-val testContainersVersion = "1.19.1"
+val testContainersVersion = "1.19.3"
 val mockkVersion = "1.13.8"
 val kluentVersion = "1.73"
 
 plugins {
     id("application")
-    kotlin("jvm") version "1.9.20"
+    kotlin("jvm") version "1.9.21"
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("com.diffplug.spotless") version "6.22.0"
+    id("com.diffplug.spotless") version "6.23.3"
 }
 
 group = "no.nav.sykmelderstatistikk"
@@ -55,7 +55,8 @@ dependencies {
 
     implementation("no.nav.helse:syfosm-common-kafka:$smCommonVersion")
 
-    implementation("org.flywaydb:flyway-core:$flywayVersion")
+    compileOnly("org.flywaydb:flyway-core:$flywayVersion")
+    implementation("org.flywaydb:flyway-database-postgresql:$flywayVersion")
     implementation("org.postgresql:postgresql:$postgresVersion")
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")


### PR DESCRIPTION
* Bump the dependencies group with 9 updates

Bumps the dependencies group with 9 updates:

| Package | From | To |
| --- | --- | --- |
| com.fasterxml.jackson.datatype:jackson-datatype-jsr310 | `2.15.3` | `2.16.0` | | [ch.qos.logback:logback-classic](https://github.com/qos-ch/logback) | `1.4.11` | `1.4.14` | | [org.flywaydb:flyway-core](https://github.com/flyway/flyway) | `9.22.3` | `10.1.0` | | [org.postgresql:postgresql](https://github.com/pgjdbc/pgjdbc) | `42.6.0` | `42.7.0` | | [org.jetbrains.exposed:exposed-core](https://github.com/JetBrains/Exposed) | `0.44.1` | `0.45.0` | | [org.jetbrains.exposed:exposed-jdbc](https://github.com/JetBrains/Exposed) | `0.44.1` | `0.45.0` | | [org.testcontainers:postgresql](https://github.com/testcontainers/testcontainers-java) | `1.19.1` | `1.19.3` | | [jvm](https://github.com/JetBrains/kotlin) | `1.9.20` | `1.9.21` | | com.diffplug.spotless | `6.22.0` | `6.23.3` |


Updates `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` from 2.15.3 to 2.16.0

Updates `ch.qos.logback:logback-classic` from 1.4.11 to 1.4.14
- [Commits](https://github.com/qos-ch/logback/compare/v_1.4.11...v_1.4.14)

Updates `org.flywaydb:flyway-core` from 9.22.3 to 10.1.0
- [Release notes](https://github.com/flyway/flyway/releases)
- [Commits](https://github.com/flyway/flyway/compare/flyway-9.22.3...flyway-10.1.0)

Updates `org.postgresql:postgresql` from 42.6.0 to 42.7.0
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/compare/REL42.6.0...REL42.7.0)

Updates `org.jetbrains.exposed:exposed-core` from 0.44.1 to 0.45.0
- [Release notes](https://github.com/JetBrains/Exposed/releases)
- [Changelog](https://github.com/JetBrains/Exposed/blob/main/docs/ChangeLog.md)
- [Commits](https://github.com/JetBrains/Exposed/compare/0.44.1...0.45.0)

Updates `org.jetbrains.exposed:exposed-jdbc` from 0.44.1 to 0.45.0
- [Release notes](https://github.com/JetBrains/Exposed/releases)
- [Changelog](https://github.com/JetBrains/Exposed/blob/main/docs/ChangeLog.md)
- [Commits](https://github.com/JetBrains/Exposed/compare/0.44.1...0.45.0)

Updates `org.testcontainers:postgresql` from 1.19.1 to 1.19.3
- [Release notes](https://github.com/testcontainers/testcontainers-java/releases)
- [Changelog](https://github.com/testcontainers/testcontainers-java/blob/main/CHANGELOG.md)
- [Commits](https://github.com/testcontainers/testcontainers-java/compare/1.19.1...1.19.3)

Updates `jvm` from 1.9.20 to 1.9.21
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v1.9.20...v1.9.21)

Updates `com.diffplug.spotless` from 6.22.0 to 6.23.3

---
updated-dependencies:
- dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-jsr310 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: dependencies
- dependency-name: ch.qos.logback:logback-classic dependency-type: direct:production update-type: version-update:semver-patch dependency-group: dependencies
- dependency-name: org.flywaydb:flyway-core dependency-type: direct:production update-type: version-update:semver-major dependency-group: dependencies
- dependency-name: org.postgresql:postgresql dependency-type: direct:production update-type: version-update:semver-minor dependency-group: dependencies
- dependency-name: org.jetbrains.exposed:exposed-core dependency-type: direct:production update-type: version-update:semver-minor dependency-group: dependencies
- dependency-name: org.jetbrains.exposed:exposed-jdbc dependency-type: direct:production update-type: version-update:semver-minor dependency-group: dependencies
- dependency-name: org.testcontainers:postgresql dependency-type: direct:production update-type: version-update:semver-patch dependency-group: dependencies
- dependency-name: jvm dependency-type: direct:production update-type: version-update:semver-patch dependency-group: dependencies
- dependency-name: com.diffplug.spotless dependency-type: direct:production update-type: version-update:semver-minor dependency-group: dependencies ...



* Added in org.flywaydb:flyway-database-postgresql

---------